### PR TITLE
Make the PythonDocumentation package optional

### DIFF
--- a/Python3/Python3.munki.recipe
+++ b/Python3/Python3.munki.recipe
@@ -115,5 +115,19 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>Process</key>
+	<array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_ids_set_optional_true</key>
+                <array>
+                    <string>org.python.Python.PythonDocumentation-3.8</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+        </dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Prior to this change, Jamf would get stuck in a loop trying to install
this package. This is because the PythonDocumentation package is
disabled in our installer_choices but is still marked as required
elsewhere.