### PR TITLE
Use FileFinder to grab the real path to the Cisco Umbrella pkg

### DIFF
--- a/Cisco Umbrella/CiscoUmbrellaRoamingClient.download.recipe
+++ b/Cisco Umbrella/CiscoUmbrellaRoamingClient.download.recipe
@@ -52,6 +52,15 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/RoamingClient_MAC_*.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: OpenDNS (7P7HQ8H646)</string>
@@ -59,7 +68,7 @@
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/RoamingClient_MAC_2.1.40.pkg</string>
+				<string>%found_filename%</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -70,7 +79,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/RoamingClient_MAC_2.1.40.pkg</string>
+				<string>%found_filename%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
If the filename of the pkg ever changed (like when there was a new version), this recipe would have failed to run. Using FileFinder, we can find the pkg with a shell glob and use the match throughout the rest of the recipe.