### PR TITLE
Updated to remove dmg and fix version

### DIFF
--- a/Cisco Umbrella/CiscoUmbrellaRoamingClient.munki.recipe
+++ b/Cisco Umbrella/CiscoUmbrellaRoamingClient.munki.recipe
@@ -49,35 +49,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/RoamingClient_MAC_*.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
+			<string>FileFinder</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%found_filename%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Removed the extra step that put the pkg inside of a dmg. Also fixed the issue that was causing to only pull in the incorrect CFBundle version from the app.